### PR TITLE
Fix logout notification

### DIFF
--- a/server/routes/session.js
+++ b/server/routes/session.js
@@ -25,7 +25,6 @@ export default (app) => {
     })
     .delete('/session', (req, reply) => {
       req.session.delete();
-      req.flash('info', i18next.t('flash.session.delete.success'));
       return reply.redirect(app.reverse('root'));
     });
 };

--- a/server/views/layouts/application.pug
+++ b/server/views/layouts/application.pug
@@ -26,14 +26,14 @@ html(lang="en").h-100
               a.nav-link(href=route('newUser'))= t('layouts.application.signUp')
     .container.h-100
 
-      - var ivents = reply.flash()
-      if ivents
-        each messages, type in ivents
+      - var events = reply.flash()
+      if events
+        each messages, type in events
           each message in messages
             div.alert(class=`alert-${getAlertClass(type)}`)= message
       else
-        -var iventLogout = { message: t('flash.session.delete.success'), type: getAlertClass('info') }
-        div.alert(class=`alert-${iventLogout.type}`)= iventLogout.message
+        - var eventLogout = { message: t('flash.session.delete.success'), type: getAlertClass('info') }
+        div.alert(class=`alert-${eventLogout.type}`)= eventLogout.message
 
       h1.my-4
         block header

--- a/server/views/layouts/application.pug
+++ b/server/views/layouts/application.pug
@@ -26,9 +26,14 @@ html(lang="en").h-100
               a.nav-link(href=route('newUser'))= t('layouts.application.signUp')
     .container.h-100
 
-      each messages, type in reply.flash()
-        each message in messages
-          div.alert(class=`alert-${getAlertClass(type)}`)= message
+      - var ivents = reply.flash()
+      if ivents
+        each messages, type in ivents
+          each message in messages
+            div.alert(class=`alert-${getAlertClass(type)}`)= message
+      else
+        -var iventLogout = { message: t('flash.session.delete.success'), type: getAlertClass('info') }
+        div.alert(class=`alert-${iventLogout.type}`)= iventLogout.message
 
       h1.my-4
         block header


### PR DESCRIPTION
After authorization and clicking on the "Logout" button, an error occurs:

`TypeError
/home/coraloreef/projects/fastify-nodejs-application/server/views/layouts/application.pug:29 27| .container.h-100 28| > 29| each messages, type in reply.flash() 30| each message in messages 31| div.alert(class=`alert-${getAlertClass(type)}`)= message 32| Cannot read property 'length' of undefined`

Because [`reply.flash()`](https://github.com/hexlet-boilerplates/fastify-nodejs-application/blob/1f33e3c4ab8540e91d0daeac21943696b906c851/server/views/layouts/application.pug#L29) does not exist after [`req.session.delete()`](https://github.com/hexlet-boilerplates/fastify-nodejs-application/blob/1f33e3c4ab8540e91d0daeac21943696b906c851/server/routes/session.js#L27).