### PR TITLE
fix: add default value to flash

### DIFF
--- a/server/views/layouts/application.pug
+++ b/server/views/layouts/application.pug
@@ -26,7 +26,7 @@ html(lang="en").h-100
               a.nav-link(href=route('newUser'))= t('layouts.application.signUp')
     .container.h-100
 
-      each messages, type in reply.flash()
+      each messages, type in reply.flash() || []
         each message in messages
           div.alert(class=`alert-${getAlertClass(type)}`)= message
 


### PR DESCRIPTION
flash causes errors in pug because it returns undefined on first call without type parameter