### PR TITLE
fix knexfile

### DIFF
--- a/knexfile.js
+++ b/knexfile.js
@@ -12,7 +12,7 @@ const migrations = {
 export const development = {
   client: 'sqlite3',
   connection: {
-    filename: './database.sqlite',
+    filename: path.resolve(__dirname, 'database.sqlite'),
   },
   useNullAsDefault: true,
   migrations,
@@ -29,7 +29,7 @@ export const test = {
 export const production = {
   client: 'sqlite3',
   connection: {
-    filename: './database.sqlite',
+    filename: path.resolve(__dirname, 'database.sqlite'),
   },
   useNullAsDefault: true,
   migrations,


### PR DESCRIPTION
Если запустить некий скрипт, работающий с базой данных из не корня проекта, то вместо подключения к существующему database.sqlite будет создан новый файл в другом месте, к которому и будет подключение. Проблему решает замена относительного пути на абсолютный путь в настройках knex поле connection.