### PR TITLE
fix signin with empty login

### DIFF
--- a/server/routes/session.js
+++ b/server/routes/session.js
@@ -17,7 +17,8 @@ export default (app) => {
         const errors = {
           email: [{ message: i18next.t('flash.session.create.error') }],
         };
-        return reply.render('session/new', { signInForm, errors });
+        reply.render('session/new', { signInForm, errors });
+        return reply;
       }
       await req.logIn(user);
       req.flash('success', i18next.t('flash.session.create.success'));


### PR DESCRIPTION
When an empty form is sent, it should not show an empty page.